### PR TITLE
Feature/pluggable scm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ working example bundled with the complete infrastructure for a gitops deep dive.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Use Case](#use-case)
 - [Features](#features)
 - [Examples](#examples)
@@ -15,13 +14,14 @@ working example bundled with the complete infrastructure for a gitops deep dive.
   - [More options](#more-options)
   - [Real life examples](#real-life-examples)
 - [Usage](#usage)
-- [Default Structure](#default-structure)
+- [Default Folder Structure](#default-folder-structure)
   - [FluxV1](#fluxv1)
     - [Plain-k8s](#plain-k8s)
     - [Helm](#helm)
   - [FluxV2](#fluxv2)
   - [ArgoCD](#argocd)
 - [GitOps-Config](#gitops-config)
+- [SCM-Provider](#scm-provider)
 - [Stages](#stages)
   - [Namespaces](#namespaces)
   - [Conventions for stages](#conventions-for-stages)
@@ -82,10 +82,12 @@ This will simply [validate](#validators) and deploy the resources from the sourc
 
 ```groovy
 def gitopsConfig = [
-    scmmCredentialsId : 'scmm-user',
-    scmmConfigRepoUrl : 'http://scmm-scm-manager/scm/repo/fluxv1/gitops',
-    scmmPullRequestBaseUrl: 'http://scmm-scm-manager/scm'',
-    scmmPullRequestRepo: 'fluxv1/gitops',
+    scm: [
+        provider:       'SCMManager',
+        credentialsId:  'scmm-user',
+        baseUrl:        'http://scmm-scm-manager/scm',
+        repositoryUrl:  'fluxv1/gitops'
+    ],
     application: 'spring-petclinic',
     stages: [
         staging: [ 
@@ -108,10 +110,12 @@ For production it will open a PR with the changes.
 
 ```groovy
 def gitopsConfig = [
-    scmmCredentialsId : 'scmm-user',
-    scmmConfigRepoUrl : 'http://scmm-scm-manager/scm/repo/fluxv1/gitops',
-    scmmPullRequestBaseUrl: 'http://scmm-scm-manager/scm'',
-    scmmPullRequestRepo: 'fluxv1/gitops',
+    scm: [
+        provider:       'SCMManager',
+        credentialsId:  'scmm-user',
+        baseUrl:        'http://scmm-scm-manager/scm',
+        repositoryUrl:  'fluxv1/gitops'
+    ],
     cesBuildLibRepo: <cesBuildLibRepo> /* Default: 'https://github.com/cloudogu/ces-build-lib' */ ,
     cesBuildLibVersion: <cesBuildLibVersion> /* Default: a recent cesBuildLibVersion see deployViaGitops.groovy */ ,
     cesBuildLibCredentialsId: <cesBuildLibCredentialsId> /* Default: '', empty due to default public github repo */,
@@ -253,10 +257,6 @@ You can find a complete yet simple example [here](#examples).
 First of all there are some mandatory properties e.g. the information about your gitops repository and the application repository.
 
 ```
-scmmCredentialsId:      'scmm-user', // ID of credentials defined in Jenkins used to authenticated with SCMM
-scmmConfigRepoUrl:      'http://scmm-scm-manager/scm/repo/fluxv1/gitops',        // this is your full gitops repo url e.g. 
-scmmPullRequestBaseUrl: 'http://scmm-scm-manager/scm',   // this is your gitops base url  
-scmmPullRequestRepo:    'fluxv1/gitops',     // this is the gitops repo     
 application:            'spring-petclinic' // Name of the application. Used as a folder in GitOps repo
 ```
 
@@ -276,17 +276,17 @@ The scm-section defines where your 'gitops-repository' resides (url, provider) a
 def gitopsConfig = [
     ...
     scm: [
-        provider:       'SCMManager',
-        credentialsId:  scmManagerCredentials,
-        baseUrl:        'http://scmm-scm-manager/scm',
-        repositoryUrl:  'fluxv1/gitops'
+        provider:       'SCMManager',   // This is the name of the scm-provider in use, for a list of supported providers watch below!
+        credentialsId:  'scmm-user',    // ID of credentials defined in Jenkins used to authenticated with SCMM
+        baseUrl:        'http://scmm-scm-manager/scm',  // this is your gitops base url 
+        repositoryUrl:  'fluxv1/gitops' // this is the gitops repo
     ],
     ...
 ]
 ```
 It currently supports the following scm-provider:
 
-- [SCM-Manager](https://www.scm-manager.org/)
+- [SCMManager](https://www.scm-manager.org/)
 
 To empower people to participate and encourage the integration of other scm-software (e.g. github), we decided to implement an abstraction for the
 scm-provider. By extending the SCM-Provider class you can integrate your own provider! Please feel free to contribute!

--- a/README.md
+++ b/README.md
@@ -268,6 +268,61 @@ mainBranch:         'main'
 ```
 ---
 
+## SCM-Provider
+
+The scm-section defines where your 'gitops-repository' resides (url, provider) and how to access it (credentials):
+
+```groovy
+def gitopsConfig = [
+    ...
+    scm: [
+        provider:       'SCMManager',
+        credentialsId:  scmManagerCredentials,
+        baseUrl:        'http://scmm-scm-manager/scm',
+        repositoryUrl:  'fluxv1/gitops'
+    ],
+    ...
+]
+```
+It currently supports the following scm-provider:
+
+- [SCM-Manager](https://www.scm-manager.org/)
+
+To empower people to participate and encourage the integration of other scm-software (e.g. github), we decided to implement an abstraction for the
+scm-provider. By extending the SCM-Provider class you can integrate your own provider! Please feel free to contribute!
+
+Example:
+
+```groovy
+import com.cloudogu.gitopsbuildlib.scm.SCMProvider
+
+class GitHub extends SCMProvider {
+    @Override
+    void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
+
+    @Override
+    void setRepositoryUrl(String repositoryUrl) { this.repositoryUrl = repositoryUrl }
+
+    @Override
+    void setCredentials(String credentialsId) { this.credentials = credentialsId }
+
+    @Override
+    String getRepositoryUrl() { return "${this.baseUrl}/${repositoryUrl}"}
+
+    @Override
+    void createOrUpdatePullRequest(String stageBranch, String mainBranch, String title, String description) {
+        // TODO: this is a specific implementation for github
+        // 1. creating a pr on the given repo with the given details
+        // 2. update a pr on the given repo if it already exists
+        //
+        // Note: Credentials given are credentialsId from Jenkins!
+    }
+}
+
+```
+
+---
+
 ## Stages
 The GitOps-build-lib supports builds on multiple stages. A stage is defined by a name and contains a namespace (used to
 generate the resources) and a deployment-flag. If no stages is passed into the gitops-config by the user, the default

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <!-- further debug possibilities
+                 <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+                <- end -->
             </plugin>
 
             <plugin>

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
@@ -1,28 +1,31 @@
 package com.cloudogu.gitopsbuildlib.scm
 
 class SCMManager extends SCMProvider {
+    protected String credentials
+    protected String baseUrl
+    protected String repositoryUrl
+
 
     SCMManager(def script) {
         super(script)
     }
 
     @Override
-    void setBaseUrl(String baseUrl) { super.baseUrl = baseUrl }
+    void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
 
     @Override
-    void setRepositoryUrl(String repositoryUrl) { super.repositoryUrl = repositoryUrl }
+    void setRepositoryUrl(String repositoryUrl) { this.repositoryUrl = repositoryUrl }
 
     @Override
-    void setCredentials(String credentialsId) { super.credentials = credentialsId }
+    void setCredentials(String credentialsId) { this.credentials = credentialsId }
 
     @Override
     String getRepositoryUrl() {
-        return "${super.baseUrl}/repo/${super.repositoryUrl}"
+        return "${this.baseUrl}/repo/${this.repositoryUrl}"
     }
 
     @Override
     void createOrUpdatePullRequest(String stageBranch, String mainBranch, String title, String description) {
-        def scmm = script.cesBuildLib.SCMManager.new(this, super.baseUrl, super.credentials)
-        scmm.createOrUpdatePullRequest(this.repositoryUrl, stageBranch, mainBranch, title, description)
+        script.cesBuildLib.SCMManager.new(script, this.baseUrl, this.credentials).createOrUpdatePullRequest(this.repositoryUrl, stageBranch, mainBranch, title, description)
     }
 }

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
@@ -8,7 +8,10 @@ class SCMManager extends SCMProvider {
 
     @Override
     String getRepositoryUrl() {
-        return "${this.baseUrl}/repo/${this.repository}"
+        if (!this.baseUrl || this.repositoryUrl)
+            return ""
+        else
+            return "${this.baseUrl}/repo/${this.repositoryUrl}"
     }
 
     @Override

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
@@ -1,0 +1,19 @@
+package com.cloudogu.gitopsbuildlib.scm
+
+class SCMManager extends SCMProvider {
+
+    SCMManager(def script) {
+        super(script)
+    }
+
+    @Override
+    String getRepositoryUrl() {
+        return "${this.baseUrl}/repo/${this.repository}"
+    }
+
+    @Override
+    void createOrUpdatePullRequest(String pullRequestRepo, String stageBranch, String mainBranch, String title, String description) {
+        def scmm = script.cesBuildLib.SCMManager.new(this, "scmmPullRequestBaseUrl", this.credentials)
+        scmm.createOrUpdatePullRequest(pullRequestRepo, stageBranch, mainBranch, title, description)
+    }
+}

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
@@ -6,20 +6,23 @@ class SCMManager extends SCMProvider {
         super(script)
     }
 
+    @Override
+    void setBaseUrl(String baseUrl) { super.baseUrl = baseUrl }
 
-    // TODO: refactor!
+    @Override
+    void setRepositoryUrl(String repositoryUrl) { super.repositoryUrl = repositoryUrl }
+
+    @Override
+    void setCredentials(String credentialsId) { super.credentials = credentialsId }
+
     @Override
     String getRepositoryUrl() {
-        if (!this.baseUrl || this.repositoryUrl)
-            return ""
-        else
-            return "${this.baseUrl}/repo/${this.repositoryUrl}"
+        return "${super.baseUrl}/repo/${super.repositoryUrl}"
     }
 
-    // TODO: PR-Url could be something different dependant on implementation and is not passed in anymore via gitopsconfig map
     @Override
-    void createOrUpdatePullRequest(String pullRequestRepo, String stageBranch, String mainBranch, String title, String description) {
-        def scmm = script.cesBuildLib.SCMManager.new(this, "scmmPullRequestBaseUrl", this.credentials)
-        scmm.createOrUpdatePullRequest(pullRequestRepo, stageBranch, mainBranch, title, description)
+    void createOrUpdatePullRequest(String stageBranch, String mainBranch, String title, String description) {
+        def scmm = script.cesBuildLib.SCMManager.new(this, super.baseUrl, super.credentials)
+        scmm.createOrUpdatePullRequest(this.repositoryUrl, stageBranch, mainBranch, title, description)
     }
 }

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMManager.groovy
@@ -6,6 +6,8 @@ class SCMManager extends SCMProvider {
         super(script)
     }
 
+
+    // TODO: refactor!
     @Override
     String getRepositoryUrl() {
         if (!this.baseUrl || this.repositoryUrl)
@@ -14,6 +16,7 @@ class SCMManager extends SCMProvider {
             return "${this.baseUrl}/repo/${this.repositoryUrl}"
     }
 
+    // TODO: PR-Url could be something different dependant on implementation and is not passed in anymore via gitopsconfig map
     @Override
     void createOrUpdatePullRequest(String pullRequestRepo, String stageBranch, String mainBranch, String title, String description) {
         def scmm = script.cesBuildLib.SCMManager.new(this, "scmmPullRequestBaseUrl", this.credentials)

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
@@ -2,13 +2,7 @@ package com.cloudogu.gitopsbuildlib.scm
 
 abstract class SCMProvider {
 
-    protected def script
-    protected String credentials = ''
-
-    // scm
-    protected String baseUrl = ''
-    protected String repositoryUrl = ''
-
+    protected script
 
     SCMProvider(def script) {
         this.script = script

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
@@ -1,0 +1,28 @@
+package com.cloudogu.gitopsbuildlib.scm
+
+abstract class SCMProvider {
+
+    protected def script
+    protected String credentials = ''
+
+    // scm
+    protected String baseUrl
+    protected String repository
+
+
+
+    SCMProvider(def script) {
+        this.script = script
+    }
+
+    void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
+
+    void setRepository(String repository) { this.repository = repository }
+
+    void setCredentials(String credentialsId) { this.credentials = credentialsId }
+
+
+    abstract String getRepositoryUrl()
+
+    abstract void createOrUpdatePullRequest(String pullRequestRepo, String stageBranch, String mainBranch, String title, String description)
+}

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
@@ -7,7 +7,7 @@ abstract class SCMProvider {
 
     // scm
     protected String baseUrl
-    protected String repository
+    protected String repositoryUrl
 
 
 
@@ -17,7 +17,7 @@ abstract class SCMProvider {
 
     void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
 
-    void setRepository(String repository) { this.repository = repository }
+    void setRepositoryUrl(String repositoryUrl) { this.repositoryUrl = repositoryUrl }
 
     void setCredentials(String credentialsId) { this.credentials = credentialsId }
 

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
@@ -6,24 +6,21 @@ abstract class SCMProvider {
     protected String credentials = ''
 
     // scm
-    protected String baseUrl
-    protected String repositoryUrl
-
+    protected String baseUrl = ''
+    protected String repositoryUrl = ''
 
 
     SCMProvider(def script) {
         this.script = script
     }
 
-    // TODO: check if implementation has to be done within the implementation itself or can be achieved like this in the base class
-    void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
+    abstract void setBaseUrl(String baseUrl)
 
-    void setRepositoryUrl(String repositoryUrl) { this.repositoryUrl = repositoryUrl }
+    abstract void setRepositoryUrl(String repositoryUrl)
 
-    void setCredentials(String credentialsId) { this.credentials = credentialsId }
-
+    abstract void setCredentials(String credentialsId)
 
     abstract String getRepositoryUrl()
 
-    abstract void createOrUpdatePullRequest(String pullRequestRepo, String stageBranch, String mainBranch, String title, String description)
+    abstract void createOrUpdatePullRequest(String stageBranch, String mainBranch, String title, String description)
 }

--- a/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/scm/SCMProvider.groovy
@@ -15,6 +15,7 @@ abstract class SCMProvider {
         this.script = script
     }
 
+    // TODO: check if implementation has to be done within the implementation itself or can be achieved like this in the base class
     void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl }
 
     void setRepositoryUrl(String repositoryUrl) { this.repositoryUrl = repositoryUrl }

--- a/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
@@ -41,23 +41,19 @@ class DeployViaGitopsTest extends BasePipelineTest {
 
     Map gitopsConfig(Map stages, Map deployments) {
         return [
-            scm: [
-                provider:        new SCMManager(deployViaGitops),
-                credentialsId:  'scmManagerCredentials',
-                baseUrl:        'http://scmm-scm-manager/scm',
-                repository:     'fluxv1/gitops'
+            scm                     : [
+                provider     : new SCMManager(deployViaGitops),
+                credentialsId: 'scmManagerCredentials',
+                baseUrl      : 'http://scmm-scm-manager/scm',
+                repositoryUrl   : 'fluxv1/gitops'
             ],
-            scmmCredentialsId     : 'scmManagerCredentials',
-            scmmConfigRepoUrl     : 'configRepositoryUrl',
-            scmmPullRequestBaseUrl: 'http://scmm-scm-manager/scm',
-            scmmPullRequestRepo   : 'fluxv1/gitops',
-            cesBuildLibRepo       : 'cesBuildLibRepo',
-            cesBuildLibVersion    : 'cesBuildLibVersion',
+            cesBuildLibRepo         : 'cesBuildLibRepo',
+            cesBuildLibVersion      : 'cesBuildLibVersion',
             cesBuildLibCredentialsId: 'cesBuildLibCredentialsId',
-            application           : 'application',
-            mainBranch            : 'main',
-            deployments           : deployments,
-            validators            : [
+            application             : 'application',
+            mainBranch              : 'main',
+            deployments             : deployments,
+            validators              : [
                 kubeval : [
                     validator: new Kubeval(deployViaGitops),
                     enabled  : true,
@@ -295,7 +291,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('configRepositoryUrl')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 
@@ -336,7 +332,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('configRepositoryUrl')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 
@@ -452,11 +448,12 @@ spec:
     void 'error on single missing mandatory field'() {
 
         def gitopsConfigMissingMandatoryField = [
-            scmmConfigRepoUrl     : 'configRepositoryUrl',
-            scmmPullRequestBaseUrl: 'configRepositoryPRBaseUrl',
-            scmmPullRequestRepo   : 'scmmPullRequestRepo',
-            application           : 'application',
-            deployments           : [
+            scm        : [
+                baseUrl   : 'http://scmm-scm-manager/scm',
+                repositoryUrl: 'fluxv1/gitops',
+            ],
+            application: 'application',
+            deployments: [
                 sourcePath: 'k8s',
                 plain     : [
                     updateImages: [
@@ -466,7 +463,7 @@ spec:
                     ]
                 ]
             ],
-            stages                : [
+            stages     : [
                 staging   : [deployDirectly: true],
                 production: [deployDirectly: false],
                 qa        : []
@@ -479,7 +476,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scm]")
+                callArgsToString(call).contains("[scm.provider]")
             }).isTrue()
     }
 
@@ -487,13 +484,13 @@ spec:
     void 'error on single non valid mandatory field'() {
 
         def gitopsConfigMissingMandatoryField = [
-            scmmCredentialsId     : 'scmManagerCredentials',
-            scmmConfigRepoUrl     : 'configRepositoryUrl',
-            scmmPullRequestBaseUrl: '',
-            scmmPullRequestRepo   : 'scmmPullRequestRepo',
-            scmmPullRequestUrl    : 'configRepositoryPRUrl',
-            application           : 'application',
-            deployments           : [
+            scm        : [
+                provider  : new SCMManager(this),
+                baseUrl   : 'http://scmm-scm-manager/scm',
+                repositoryUrl: 'fluxv1/gitops',
+            ],
+            application: '',
+            deployments: [
                 sourcePath: 'k8s',
                 plain     : [
                     updateImages: [
@@ -503,7 +500,7 @@ spec:
                     ]
                 ]
             ],
-            stages                : [
+            stages     : [
                 staging   : [deployDirectly: true],
                 production: [deployDirectly: false],
                 qa        : []
@@ -516,7 +513,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scm]")
+                callArgsToString(call).contains("[application]")
             }).isTrue()
     }
 
@@ -524,9 +521,13 @@ spec:
     void 'error on missing or non valid values on mandatory fields'() {
 
         def gitopsConfigMissingMandatoryField = [
-            scmmPullRequestBaseUrl: null,
-            application           : '',
-            stages                : []
+            scm        : [
+                credentialsId: 'scmManagerCredentials',
+                baseUrl      : 'http://scmm-scm-manager/scm',
+                repositoryUrl   : 'fluxv1/gitops',
+            ],
+            application: '',
+            stages     : []
         ]
 
         gitRepo.use {
@@ -535,7 +536,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scm, application, stages]")
+                callArgsToString(call).contains("[scm.provider, application, stages]")
             }).isTrue()
     }
 

--- a/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
@@ -452,7 +452,6 @@ spec:
                 baseUrl   : 'http://scmm-scm-manager/scm',
                 repositoryUrl: 'fluxv1/gitops',
             ],
-            deployments: [
             gitopsTool            : 'FLUX_V1',
             deployments           : [
                 sourcePath: 'k8s',

--- a/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
@@ -2,8 +2,7 @@ package com.cloudogu.gitopsbuildlib
 
 import com.cloudogu.ces.cesbuildlib.DockerMock
 import com.cloudogu.ces.cesbuildlib.Git
-import com.cloudogu.ces.cesbuildlib.SCMManager
-
+import com.cloudogu.gitopsbuildlib.scm.SCMManager
 import com.cloudogu.gitopsbuildlib.validation.Kubeval
 import com.cloudogu.gitopsbuildlib.validation.Yamllint
 import com.lesfurets.jenkins.unit.BasePipelineTest
@@ -42,6 +41,12 @@ class DeployViaGitopsTest extends BasePipelineTest {
 
     Map gitopsConfig(Map stages, Map deployments) {
         return [
+            scm: [
+                provider:        new SCMManager(deployViaGitops),
+                credentialsId:  'scmManagerCredentials',
+                baseUrl:        'http://scmm-scm-manager/scm',
+                repository:     'fluxv1/gitops'
+            ],
             scmmCredentialsId     : 'scmManagerCredentials',
             scmmConfigRepoUrl     : 'configRepositoryUrl',
             scmmPullRequestBaseUrl: 'http://scmm-scm-manager/scm',
@@ -113,7 +118,7 @@ class DeployViaGitopsTest extends BasePipelineTest {
         cesBuildLibMock = new CesBuildLibMock()
         git = mock(Git.class)
         docker = new DockerMock().createMock()
-        scmm = mock(SCMManager.class)
+        scmm = mock(com.cloudogu.ces.cesbuildlib.SCMManager.class)
 
         cesBuildLibMock.Docker.new = {
             return docker
@@ -453,7 +458,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scmmCredentialsId]")
+                callArgsToString(call).contains("[scm]")
             }).isTrue()
     }
 
@@ -490,7 +495,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scmmPullRequestBaseUrl]")
+                callArgsToString(call).contains("[scm]")
             }).isTrue()
     }
 
@@ -509,7 +514,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scmmCredentialsId, scmmConfigRepoUrl, scmmPullRequestBaseUrl, scmmPullRequestRepo, application, stages]")
+                callArgsToString(call).contains("[scm, application, stages]")
             }).isTrue()
     }
 

--- a/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
@@ -42,10 +42,10 @@ class DeployViaGitopsTest extends BasePipelineTest {
     Map gitopsConfig(Map stages, Map deployments) {
         return [
             scm                     : [
-                provider     : new SCMManager(deployViaGitops),
+                provider     : 'SCMManager',
                 credentialsId: 'scmManagerCredentials',
                 baseUrl      : 'http://scmm-scm-manager/scm',
-                repositoryUrl   : 'fluxv1/gitops'
+                repositoryUrl   : 'fluxv1/gitops',
             ],
             cesBuildLibRepo         : 'cesBuildLibRepo',
             cesBuildLibVersion      : 'cesBuildLibVersion',
@@ -291,7 +291,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('fluxv1/gitops')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 
@@ -332,7 +332,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('fluxv1/gitops')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 
@@ -485,7 +485,7 @@ spec:
 
         def gitopsConfigMissingMandatoryField = [
             scm        : [
-                provider  : new SCMManager(this),
+                provider  : 'SCMManager',
                 baseUrl   : 'http://scmm-scm-manager/scm',
                 repositoryUrl: 'fluxv1/gitops',
             ],
@@ -524,7 +524,7 @@ spec:
             scm        : [
                 credentialsId: 'scmManagerCredentials',
                 baseUrl      : 'http://scmm-scm-manager/scm',
-                repositoryUrl   : 'fluxv1/gitops',
+                repositoryUrl   : '',
             ],
             application: '',
             stages     : []
@@ -536,7 +536,7 @@ spec:
 
         assertThat(
             helper.callStack.findAll { call -> call.methodName == "error" }.any { call ->
-                callArgsToString(call).contains("[scm.provider, application, stages]")
+                callArgsToString(call).contains("[scm.provider, scm.repositoryUrl, application, stages]")
             }).isTrue()
     }
 

--- a/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/DeployViaGitopsTest.groovy
@@ -2,7 +2,6 @@ package com.cloudogu.gitopsbuildlib
 
 import com.cloudogu.ces.cesbuildlib.DockerMock
 import com.cloudogu.ces.cesbuildlib.Git
-import com.cloudogu.gitopsbuildlib.scm.SCMManager
 import com.cloudogu.gitopsbuildlib.validation.Kubeval
 import com.cloudogu.gitopsbuildlib.validation.Yamllint
 import com.lesfurets.jenkins.unit.BasePipelineTest
@@ -291,7 +290,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('fluxv1/gitops')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('http://scmm-scm-manager/scm/repo/fluxv1/gitops')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 
@@ -332,7 +331,7 @@ spec:
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class)
         verify(git).call(argumentCaptor.capture())
-        assertThat(argumentCaptor.getValue().url).isEqualTo('fluxv1/gitops')
+        assertThat(argumentCaptor.getValue().url).isEqualTo('http://scmm-scm-manager/scm/repo/fluxv1/gitops')
         assertThat(argumentCaptor.getValue().branch).isEqualTo('main')
         verify(git, times(1)).fetch()
 

--- a/test/com/cloudogu/gitopsbuildlib/GitMock.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/GitMock.groovy
@@ -1,11 +1,6 @@
 package com.cloudogu.ces.cesbuildlib
 
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
-
-import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.when
 
 class GitMock {
     List<String> actualArgs = new LinkedList<>()

--- a/test/com/cloudogu/gitopsbuildlib/ScriptMock.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/ScriptMock.groovy
@@ -12,6 +12,7 @@ class ScriptMock {
     List<String> actualShArgs = new LinkedList<>()
     List<String> actualEchoArgs = new LinkedList<>()
     List<String> actualReadYamlArgs = new LinkedList<>()
+    List<String> actualGitArgs = new LinkedList<>()
     String actualDir
     def configYaml = '''\
 ---
@@ -43,7 +44,7 @@ to:
                     ],
                 ],
             docker: dockerMock.createMock(),
-            git: gitMock.createMock(),
+            git: { args -> actualGitArgs += args.toString() },
             pwd   : { 'pwd' },
             sh    : { args -> actualShArgs += args.toString() },
             echo  : { args -> actualEchoArgs += args.toString() },

--- a/test/com/cloudogu/gitopsbuildlib/deployment/DeploymentTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/DeploymentTest.groovy
@@ -4,7 +4,7 @@ import com.cloudogu.gitopsbuildlib.ScriptMock
 import com.cloudogu.gitopsbuildlib.validation.HelmKubeval
 import com.cloudogu.gitopsbuildlib.validation.Kubeval
 import com.cloudogu.gitopsbuildlib.validation.Yamllint
-import org.junit.Test
+import org.junit.jupiter.api.*
 import static org.assertj.core.api.Assertions.assertThat
 
 class DeploymentTest {

--- a/test/com/cloudogu/gitopsbuildlib/deployment/HelmTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/HelmTest.groovy
@@ -1,7 +1,7 @@
 package com.cloudogu.gitopsbuildlib.deployment
 
 import com.cloudogu.gitopsbuildlib.ScriptMock
-import org.junit.Test
+import org.junit.jupiter.api.*
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -66,14 +66,11 @@ class HelmTest {
         helmGit.createPreValidation('staging')
 
         assertThat(dockerMock.actualImages[0]).isEqualTo('ghcr.io/cloudogu/helm:3.4.1-1')
-        assertThat(scriptMock.actualShArgs[0]).isEqualTo('git clone repoUrl workspace/chart || true')
-        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
-        assertThat(scriptMock.actualShArgs[2]).isEqualTo('rm -rf workspace/chart || true')
-        assertThat(scriptMock.actualShArgs[3]).isEqualTo('rm staging/testapp/mergedValues.yaml')
-        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:staging/testapp/mergedValues.yaml, ' +
-            'text:[git clone repoUrl workspace/chart || true, ' +
-            '[returnStdout:true, ' +
-            'script:helm values workspace/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
+        assertThat(scriptMock.actualShArgs[0]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
+        assertThat(scriptMock.actualShArgs[1]).isEqualTo('rm -rf workspace/chart || true')
+        assertThat(scriptMock.actualShArgs[2]).isEqualTo('rm staging/testapp/mergedValues.yaml')
+        assertThat(scriptMock.actualGitArgs[0]).isEqualTo('[url:repoUrl, branch:main, changelog:false, poll:false]')
+        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:staging/testapp/mergedValues.yaml, text:[[returnStdout:true, script:helm values workspace/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
         assertThat(scriptMock.actualWriteFileArgs[1]).isEqualTo('[file:staging/testapp/helmRelease.yaml, text:apiVersion: helm.fluxcd.io/v1\n' +
             'kind: HelmRelease\n' +
             'metadata:\n' +

--- a/test/com/cloudogu/gitopsbuildlib/deployment/PlainTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/PlainTest.groovy
@@ -1,7 +1,7 @@
 package com.cloudogu.gitopsbuildlib.deployment
 
 import com.cloudogu.gitopsbuildlib.ScriptMock
-import org.junit.Test
+import org.junit.jupiter.api.*
 import static org.assertj.core.api.Assertions.assertThat
 
 

--- a/test/com/cloudogu/gitopsbuildlib/deployment/repotype/GitRepoTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/repotype/GitRepoTest.groovy
@@ -1,13 +1,8 @@
 package com.cloudogu.gitopsbuildlib.deployment.repotype
 
 import com.cloudogu.gitopsbuildlib.ScriptMock
-import org.junit.Test
+import org.junit.jupiter.api.*
 
-import static org.assertj.core.api.Assertions.assertThat
-import static org.assertj.core.api.Assertions.assertThat
-import static org.assertj.core.api.Assertions.assertThat
-import static org.assertj.core.api.Assertions.assertThat
-import static org.assertj.core.api.Assertions.assertThat
 import static org.assertj.core.api.Assertions.assertThat
 
 class GitRepoTest {
@@ -26,9 +21,9 @@ class GitRepoTest {
             'file2'
         ] as String[])
 
-        assertThat(scriptMock.actualShArgs[0]).isEqualTo('git clone url workspace/chart || true')
-        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/chartPath -f file1 -f file2 ]')
-        assertThat(scriptMock.actualShArgs[2]).isEqualTo('rm -rf workspace/chart || true')
+        assertThat(scriptMock.actualShArgs[0]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/chartPath -f file1 -f file2 ]')
+        assertThat(scriptMock.actualShArgs[1]).isEqualTo('rm -rf workspace/chart || true')
+        assertThat(scriptMock.actualGitArgs[0]).isEqualTo('[url:url, branch:main, changelog:false, poll:false]')
     }
 
     @Test

--- a/test/com/cloudogu/gitopsbuildlib/deployment/repotype/HelmRepoTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/repotype/HelmRepoTest.groovy
@@ -1,7 +1,7 @@
 package com.cloudogu.gitopsbuildlib.deployment.repotype
 
 import com.cloudogu.gitopsbuildlib.ScriptMock
-import org.junit.Test
+import org.junit.jupiter.api.*
 import static org.assertj.core.api.Assertions.assertThat
 
 class HelmRepoTest {

--- a/test/com/cloudogu/gitopsbuildlib/deployment/repotype/RepoTypeTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/repotype/RepoTypeTest.groovy
@@ -1,7 +1,7 @@
 package com.cloudogu.gitopsbuildlib.deployment.repotype
 
 import com.cloudogu.gitopsbuildlib.ScriptMock
-import org.junit.Test
+import org.junit.jupiter.api.*
 import static org.assertj.core.api.Assertions.assertThat
 
 class RepoTypeTest {

--- a/vars/deployViaGitops.groovy
+++ b/vars/deployViaGitops.groovy
@@ -184,7 +184,7 @@ protected void deploy(Map gitopsConfig) {
     try {
         dir(gitRepo.configRepoTempDir) {
 
-            git url: gitopsConfig.scm.repositoryUrl, branch: gitopsConfig.mainBranch, changelog: false, poll: false
+            git url: provider.getRepositoryUrl(), branch: gitopsConfig.mainBranch, changelog: false, poll: false
             git.fetch()
 
             changesOnGitOpsRepo = aggregateChangesOnGitOpsRepo(syncGitopsRepoPerStage(gitopsConfig, git, gitRepo))


### PR DESCRIPTION
Introduce the abstract base class 'SCMProvider'. 

Enables us to extend the gitops-lib by providing the possibility to use different scm for the gitops repository itself.
First draft only contains implementation for the scm-manager. 