### PR TITLE
Add welcome message and print actual config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add welcome message and print configs at application start
+
 ### Changed
 - Disable yamllint image due to image is not longer maintained 
 

--- a/vars/deployViaGitops.groovy
+++ b/vars/deployViaGitops.groovy
@@ -100,6 +100,7 @@ void call(Map gitopsConfig) {
     // Merge default config with the one passed as parameter
     gitopsConfig = mergeMaps(createDefaultConfig(gitopsConfig.k8sVersion as String), gitopsConfig)
     if (validateConfig(gitopsConfig)) {
+        printWelcomeAndConfigs(gitopsConfig)
         cesBuildLib = initCesBuildLib(gitopsConfig.cesBuildLibRepo, gitopsConfig.cesBuildLibVersion, gitopsConfig.cesBuildLibCredentialsId)
         deploy(gitopsConfig)
     }
@@ -341,6 +342,27 @@ protected String createBuildDescription(String pushedChanges) {
         description += 'No changes'
     }
     return description
+}
+
+private printWelcomeAndConfigs(Map gitopsConfig){
+
+    print("""
+################################################################################################################
+
+           _ _                         _           _ _     _        _ _ _     
+          (_) |                       | |         (_) |   | |      | (_) |    
+      __ _ _| |_ ___  _ __  ___ ______| |__  _   _ _| | __| |______| |_| |__  
+     / _` | | __/ _ \\| '_ \\/ __|______| '_ \\| | | | | |/ _` |______| | | '_ \\ 
+    | (_| | | || (_) | |_) \\__ \\      | |_) | |_| | | | (_| |      | | | |_) |
+     \\__, |_|\\__\\___/| .__/|___/      |_.__/ \\__,_|_|_|\\__,_|      |_|_|_.__/ 
+      __/ |          | |                                                      
+     |___/           |_|                                                      
+  
+    config:
+${gitopsConfig.collect { key, value -> "        $key: $value" }.join("\n")}
+     
+################################################################################################################
+""")
 }
 
 def cesBuildLib


### PR DESCRIPTION
Adding a ASCII art logo and printing the configs. 
Purpose:  better visibility in larger job logs and improved boundary to other pipeline steps. Applied configs can be checked directly at the start 
![gitops build lib](https://github.com/user-attachments/assets/767dbab1-5805-46d6-8685-4264004ab728)
