### PR TITLE
Replaced the dependency for the kubectl call. / The functionality can be tested inside the GOP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/cloudogu/gitops-build-lib/releases/tag/0.7.0) - 2024-10-14
+
 ### Added
 - Add additional docker runs args support
 - Add welcome message and print configs at application start

--- a/test/com/cloudogu/gitopsbuildlib/deployment/DeploymentTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/DeploymentTest.groovy
@@ -91,12 +91,7 @@ class DeploymentTest {
     void 'create configmaps from files'() {
 
         deploymentUnderTest.createFileConfigmaps('staging')
-
-        assertThat(scriptMock.dockerMock.actualRegistryArgs[0]).isEqualTo('https://http://my-private-registry.com/repo')
-        assertThat(scriptMock.dockerMock.actualRegistryArgs[1]).isEqualTo('credentials')
-
-        assertThat(scriptMock.actualShArgs[0]).isEqualTo('[returnStdout:true, script:kubectl create configmap index --from-file=index.html=workspace/k8s/../index.html --dry-run=client -o yaml -n fluxv1-staging]')
-
+        assertThat(scriptMock.actualWriteYamlArgs[0]).contains('apiVersion', 'kind', 'metadata', 'ConfigMap')
         assertThat(scriptMock.actualWriteFileArgs[0]).contains('[file:staging/app/generatedResources/index.yaml')
     }
 


### PR DESCRIPTION
How to test:

### Option 1: Jenkins replay

Force Jenkins to replay a build in the Deployment.class with the modified method under:
 `http://jenkins.localhost/job/example-apps/job/petclinic-plain/job/main/`

### Option 2: Local testing

1. Pull the changes from this PR into your local scmm repo of the gitop-build-library.
2. Modify the following Jenkinsfile to use a tag or branch:
`http://scmm.localhost/scm/repo/argocd/nginx-helm-jenkins/code/sources/main/Jenkinsfile#L12`
3. Commit the changes.
4. Check the result in the built Argo CD repo:
`http://scmm.localhost/scm/repo/argocd/example-apps/code/sources/main/apps/nginx-helm-jenkins/staging/generatedResources/index-nginx.yaml

You should see the generated ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: index-nginx
  namespace: example-apps-staging
data:
  index.html: |-
    <!DOCTYPE html>
    <html>
    <head>
        <meta charset="utf-8">
        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
        <title>cloudogu/gitops-playground2</title>
    </head>
    <body>
    <h2>Hello cloudogu gitops playground!</h2>
    </body>
    </html>
```

