### PR TITLE
fix helm shared value argument position

### DIFF
--- a/src/com/cloudogu/gitopsbuildlib/deployment/helm/Helm.groovy
+++ b/src/com/cloudogu/gitopsbuildlib/deployment/helm/Helm.groovy
@@ -40,7 +40,7 @@ class Helm extends Deployment {
         def valueFiles = ["${script.env.WORKSPACE}/${sourcePath}/values-${stage}.yaml"]
         // only add values-shared.yaml, if it exists
         if (script.fileExists("${script.env.WORKSPACE}/${sourcePath}/values-shared.yaml")) {
-            valueFiles.add("${script.env.WORKSPACE}/${sourcePath}/values-shared.yaml")
+            valueFiles.add(0, "${script.env.WORKSPACE}/${sourcePath}/values-shared.yaml")
         }
         script.writeFile file: "${script.env.WORKSPACE}/${HELM_CHART_TEMP_DIR}/mergedValues.yaml", text: mergeValuesFiles(gitopsConfig, valueFiles as String[], repoType)
 

--- a/test/com/cloudogu/gitopsbuildlib/deployment/HelmTest.groovy
+++ b/test/com/cloudogu/gitopsbuildlib/deployment/HelmTest.groovy
@@ -114,8 +114,8 @@ to:
 
         assertThat(dockerMock.actualImages[0]).contains('helmImage')
         assertThat(scriptMock.actualShArgs[0]).isEqualTo('helm dep update workspace/.helmChartTempDir/chart/chartPath')
-        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
-        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm dep update workspace/.helmChartTempDir/chart/chartPath, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
+        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]')
+        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm dep update workspace/.helmChartTempDir/chart/chartPath, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]]]')
         assertThat(scriptMock.actualWriteFileArgs[1]).isEqualTo('''[file:staging/app/applicationRelease.yaml, text:apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -145,8 +145,8 @@ spec:
         assertThat(scriptMock.actualShArgs[0]).isEqualTo('helm repo add chartRepo repoUrl')
         assertThat(scriptMock.actualShArgs[1]).isEqualTo('helm repo update')
         assertThat(scriptMock.actualShArgs[2]).isEqualTo('helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart')
-        assertThat(scriptMock.actualShArgs[3]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
-        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm repo add chartRepo repoUrl, helm repo update, helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
+        assertThat(scriptMock.actualShArgs[3]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]')
+        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm repo add chartRepo repoUrl, helm repo update, helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]]]')
         assertThat(scriptMock.actualWriteFileArgs[1]).isEqualTo('''[file:staging/app/applicationRelease.yaml, text:apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -177,8 +177,8 @@ spec:
 
         assertThat(dockerMock.actualImages[0]).contains('helmImage')
         assertThat(scriptMock.actualShArgs[0]).isEqualTo('helm dep update workspace/.helmChartTempDir/chart/chartPath')
-        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
-        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm dep update workspace/.helmChartTempDir/chart/chartPath, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
+        assertThat(scriptMock.actualShArgs[1]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]')
+        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm dep update workspace/.helmChartTempDir/chart/chartPath, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartPath -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]]]')
         assertThat(scriptMock.actualWriteFileArgs[1]).isEqualTo('''[file:apps/app/staging/applicationRelease.yaml, text:apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -211,8 +211,8 @@ spec:
         assertThat(scriptMock.actualShArgs[0]).isEqualTo('helm repo add chartRepo repoUrl')
         assertThat(scriptMock.actualShArgs[1]).isEqualTo('helm repo update')
         assertThat(scriptMock.actualShArgs[2]).isEqualTo('helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart')
-        assertThat(scriptMock.actualShArgs[3]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
-        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm repo add chartRepo repoUrl, helm repo update, helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]]]')
+        assertThat(scriptMock.actualShArgs[3]).isEqualTo('[returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]')
+        assertThat(scriptMock.actualWriteFileArgs[0]).isEqualTo('[file:workspace/.helmChartTempDir/mergedValues.yaml, text:[helm repo add chartRepo repoUrl, helm repo update, helm pull chartRepo/chartName --version=1.0 --untar --untardir=workspace/.helmChartTempDir/chart, [returnStdout:true, script:helm values workspace/.helmChartTempDir/chart/chartName -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]]]')
         assertThat(scriptMock.actualWriteFileArgs[1]).isEqualTo('''[file:apps/app/staging/applicationRelease.yaml, text:apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -283,6 +283,6 @@ spec:
         helmLocal.preValidation('staging')
 
         assertThat(dockerMock.actualImages[0]).contains('helmImage')
-        assertThat(scriptMock.actualShArgs[0]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/path -f workspace/k8s/values-staging.yaml -f workspace/k8s/values-shared.yaml ]')
+        assertThat(scriptMock.actualShArgs[0]).isEqualTo('[returnStdout:true, script:helm values workspace/chart/path -f workspace/k8s/values-shared.yaml -f workspace/k8s/values-staging.yaml ]')
     }
 }


### PR DESCRIPTION
# How to Test the Fix

## Notes:
- Running GOP checkout is required
- Testing of the fix is done with the petclinc-helm i.e.

### 1. Prepare the GitOps Build Lib

Fetch the fix branch from GitHub:
 https://github.com/cloudogu/gitops-build-lib/tree/bugfix/helm-wrong-order-with-values-shared

Edit the remotes and push this fix branch into the Gob SCM Manager repository of gitops-build-lib.

### 2. Update the Petclinic Helm Repo

Open the Jenkinsfile in the petclinic-helm repo and change the Version String:
http://scmm.localhost/scm/repo/argocd/petclinic-helm/code/sources/main/Jenkinsfile/

`
String getGitOpsBuildLibVersion() { '0.7.0'}
`

to

`
String getGitOpsBuildLibVersion() { 'bugfix/helm-wrong-order-with-values-shared'}
`

Jenkins should now start building and redeploying petclinic. Wait for finishing the Jenkins Build.

### 3. Verify the Fix

Edit values-shared.yaml:
http://scmm.localhost/scm/repo/argocd/petclinic-helm/code/sources/main/k8s/values-shared.yaml

Add an extra environment variable:

```
extraEnv: |
  ...
  - name: Foo
    value: Bar
```

Edit values-staging.yaml:
http://scmm.localhost/scm/repo/argocd/petclinic-helm/code/sources/main/k8s/values-staging.yaml

Add another variable:
```
extraEnv: |
  ...
  - name: Foo
    value: Baz
```

### 4. Expected Behavior

After the container build, the environment variables should respect staging overrides:

Foo=Bar (from shared) Foo=Baz (from staging)

## Additional note: Helm chart substitution use the helm template command e.g.
`
Wrong: helm template bla spring-boot-helm-chart-with-dependency/ -f petclinic-helm/k8s/values-staging.yaml -f petclinic-helm/k8s/values-shared.yaml
Correct: helm template bla spring-boot-helm-chart-with-dependency/ -f petclinic-helm/k8s/values-shared.yaml -f petclinic-helm/
`